### PR TITLE
Fix r0.1 tooltip on orangecrab homepage

### DIFF
--- a/documentation/hugo-files/layouts/home.html
+++ b/documentation/hugo-files/layouts/home.html
@@ -21,7 +21,7 @@
             <tr>
               <td style="text-align: center; width: 50%; border: none;">
                 <a href="r0.1" style="border: 0;">
-                    {{ `![r0.1 Photo](r0.1/OrangeCrab_r0.1_front.jpeg "r0.2 Photo")` | markdownify }}
+                    {{ `![r0.1 Photo](r0.1/OrangeCrab_r0.1_front.jpeg "r0.1 Photo")` | markdownify }}
                     <h2 style="margin: 0;">r0.1</h2>
                 </a>
               </td>


### PR DESCRIPTION
I noticed the image mouseover tooltip was incorrect, small fix